### PR TITLE
tar i bruk embedded document på sykmeldingene og søknadene

### DIFF
--- a/src/main/kotlin/no/nav/helse/sykmelding/SykmeldingProbe.kt
+++ b/src/main/kotlin/no/nav/helse/sykmelding/SykmeldingProbe.kt
@@ -1,7 +1,7 @@
 package no.nav.helse.sykmelding
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.prometheus.client.Counter
+import no.nav.helse.sykmelding.domain.Sykmelding
 import org.slf4j.LoggerFactory
 
 class SykmeldingProbe {
@@ -12,8 +12,8 @@ class SykmeldingProbe {
                 .register()
     }
 
-    fun mottattSykmelding(key: String, sykmelding: JsonNode) {
-        log.info("mottok sykmelding med key=$key")
+    fun mottattSykmelding(sykmelding: Sykmelding) {
+        log.info("mottok sykmelding med id=${sykmelding.id}")
         sykmeldingCounter.inc()
     }
 }

--- a/src/main/kotlin/no/nav/helse/sykmelding/domain/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helse/sykmelding/domain/Sykmelding.kt
@@ -1,0 +1,8 @@
+package no.nav.helse.sykmelding.domain
+
+import com.fasterxml.jackson.databind.JsonNode
+
+data class Sykmelding(private val jsonNode: JsonNode) {
+
+    val id = jsonNode["id"].asText()!!
+}

--- a/src/main/kotlin/no/nav/helse/søknad/SøknadProbe.kt
+++ b/src/main/kotlin/no/nav/helse/søknad/SøknadProbe.kt
@@ -1,7 +1,7 @@
 package no.nav.helse.søknad
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.prometheus.client.Counter
+import no.nav.helse.søknad.domain.Sykepengesøknad
 import org.slf4j.LoggerFactory
 
 class SøknadProbe {
@@ -13,8 +13,8 @@ class SøknadProbe {
                 .register()
     }
 
-    fun mottattSøknad(key: String, søknad: JsonNode) {
-        log.info("mottok søknad med key=$key")
+    fun mottattSøknad(søknad: Sykepengesøknad) {
+        log.info("mottok søknad med id=${søknad.id} for sykmelding=${søknad.sykmeldingId}")
         søknadCounter.inc()
     }
 }

--- a/src/main/kotlin/no/nav/helse/søknad/domain/Sykepengesøknad.kt
+++ b/src/main/kotlin/no/nav/helse/søknad/domain/Sykepengesøknad.kt
@@ -1,0 +1,10 @@
+package no.nav.helse.søknad.domain
+
+import com.fasterxml.jackson.databind.JsonNode
+
+data class Sykepengesøknad(private val jsonNode: JsonNode) {
+
+    val id = jsonNode["id"].asText()!!
+
+    val sykmeldingId = jsonNode["sykmeldingId"].asText()!!
+}

--- a/src/test/kotlin/no/nav/helse/sykmelding/domain/SykmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helse/sykmelding/domain/SykmeldingTest.kt
@@ -1,0 +1,32 @@
+package no.nav.helse.sykmelding.domain
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SykmeldingTest {
+
+    companion object {
+
+        private val objectMapper = jacksonObjectMapper()
+                .registerModule(JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+        private val testSykmelding = Sykmelding(objectMapper.readTree(sykmelding_json))
+    }
+
+    @Test
+    fun `skal svare med id`() {
+        assertEquals("71bd853d-36a1-49df-a34c-6e02cf727cfa", testSykmelding.id)
+    }
+}
+
+private val sykmelding_json = """
+{
+    "id": "71bd853d-36a1-49df-a34c-6e02cf727cfa",
+    "fnr": "11111111111",
+    "lege": "Hans Hansen"
+}
+""".trimIndent()

--- a/src/test/kotlin/no/nav/helse/søknad/domain/SykepengesøknadTest.kt
+++ b/src/test/kotlin/no/nav/helse/søknad/domain/SykepengesøknadTest.kt
@@ -1,0 +1,38 @@
+package no.nav.helse.søknad.domain
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SykepengesøknadTest {
+
+    companion object {
+
+        private val objectMapper = jacksonObjectMapper()
+                .registerModule(JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+        private val testSøknad = Sykepengesøknad(objectMapper.readTree(søknad_json))
+    }
+
+    @Test
+    fun `skal svare med id`() {
+        assertEquals("68da259c-ff7f-47cf-8fa0-c348ae95e220", testSøknad.id)
+    }
+
+    @Test
+    fun `skal svare med sykmeldingId`() {
+        assertEquals("71bd853d-36a1-49df-a34c-6e02cf727cfa", testSøknad.sykmeldingId)
+    }
+}
+
+private val søknad_json = """
+{
+    "id": "68da259c-ff7f-47cf-8fa0-c348ae95e220",
+    "sykmeldingId": "71bd853d-36a1-49df-a34c-6e02cf727cfa",
+    "status": "NY",
+    "arbeidsgiver": "Nærbutikken AS"
+}
+""".trimIndent()


### PR DESCRIPTION
Fordi formatet på meldingene kan endres over tid, og at vi i utgangspunktet ikke har behov for å behandlene meldingene i sin helhet, tar vi i bruk Embedded Document som en teknikk for å være så tolerant som mulig for endringer. Samtidig bevarer/beholder vi originalmeldingen slik at vi kan sende den videre, uforandret.

https://martinfowler.com/bliki/EmbeddedDocument.html
https://martinfowler.com/bliki/TolerantReader.html