### PR TITLE
Egen workflow for å bygge og deploye brancher prefikset med deploy-dev/

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,64 @@
+name: Bygg og deploy branch til test
+
+on:
+  push:
+    branches:
+    - deploy-dev/*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump runner context
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump steps context
+      env:
+        STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    - uses: actions/checkout@v1
+    - name: test and build
+      run: ./gradlew test build
+    - name: build docker image
+      run: docker build . --pull -t ${DOCKER_IMAGE}:$(echo $GITHUB_SHA | cut -c1-7)
+      env:
+        DOCKER_IMAGE: navikt/spsak
+    - name: push docker image
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+        docker push ${DOCKER_IMAGE}:$(echo $GITHUB_SHA | cut -c1-7)
+      env:
+        DOCKER_IMAGE: navikt/spsak
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v1
+    - name: deploy to preprod
+      env:
+        DOCKER_IMAGE: navikt/spsak
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NAV_CLUSTER: dev-fss
+        NAISERATOR_FILE: deploy/preprod.json
+      run: |
+        NAISERATOR=$(jq '.spec.image = "'$DOCKER_IMAGE':'$(echo $GITHUB_SHA | cut -c1-7)'"' -c $NAISERATOR_FILE )
+        DEPLOY_PAYLOAD=$(jq '.payload.kubernetes.resources += ['$NAISERATOR']' deploy/deployreq.json)
+        DEPLOY_PAYLOAD=$(echo $DEPLOY_PAYLOAD | jq '.environment = "'$NAV_CLUSTER'"')
+        DEPLOY_PAYLOAD=$(echo $DEPLOY_PAYLOAD | jq '.ref = "'$(echo $GITHUB_SHA | cut -c1-7)'"')
+        curl -i -n --fail \
+           -X POST \
+           -u x-access-token:$GITHUB_TOKEN \
+           -d "$DEPLOY_PAYLOAD" \
+           -H "Accept: application/vnd.github.ant-man-preview+json" \
+           https://api.github.com/repos/$GITHUB_REPOSITORY/deployments

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -3,7 +3,7 @@ name: Bygg og deploy branch til test
 on:
   push:
     branches:
-    - deploy-dev/*
+    - deploy-preprod/*
 
 jobs:
   build:


### PR DESCRIPTION
En egen workflow for å kunne deploye brancher til dev

Noen ganger kan det være greit å kunne teste ut kode uten å prodsette det på direkten. For eksempel om en tweeker på bygg- / alerts- og andre infrastrukturrelaterte ting. Denne workflowen vil fange opp alle pushes på brancher prefikset med `dev-deploy/` og bygge og deploye dem til dev