### PR TITLE
Alerts for mangel mottak av sykmelding og søknader

### DIFF
--- a/deploy/alerts-preprod.json
+++ b/deploy/alerts-preprod.json
@@ -22,6 +22,24 @@
         "action": "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger",
         "sla": "respond within 1h, during office hours",
         "severity": "danger"
+      },
+      {
+        "alert": "spsak-mottar-ikke-sykmeldinger",
+        "expr": "sum(increase(sykmeldinger_totals{app=\"spsak\"}[7d])) < 1",
+        "for": "5m",
+        "description": "spsak har ikke mottatt en sykmelding i test på 7 dager",
+        "action": "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger",
+        "sla": "ingen",
+        "severity": "danger"
+      },
+      {
+        "alert": "spsak-mottar-ikke-soknader",
+        "expr": "sum(increase(soknader_totals{app=\"spsak\"}[7d])) < 1",
+        "for": "5m",
+        "description": "spsak har ikke mottatt en søknad i test på 7 dager",
+        "action": "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger",
+        "sla": "ingen",
+        "severity": "danger"
       }
     ]
   }

--- a/deploy/alerts-prod.json
+++ b/deploy/alerts-prod.json
@@ -22,6 +22,24 @@
         "action": "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger",
         "sla": "respond within 1h, during office hours",
         "severity": "danger"
+      },
+      {
+        "alert": "spsak-mottar-ikke-sykmeldinger",
+        "expr": "sum(increase(sykmeldinger_totals{app=\"spsak\"}[60m])) < 1 AND hour() > 8 AND hour() < 20",
+        "for": "5m",
+        "description": "spsak har ikke mottatt en eneste sykmelding siste timen",
+        "action": "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger",
+        "sla": "respond within 1h, during office hours",
+        "severity": "danger"
+      },
+      {
+        "alert": "spsak-mottar-ikke-soknader",
+        "expr": "sum(increase(soknader_totals{app=\"spsak\"}[60m])) < 1 AND hour() > 8 AND hour() < 20",
+        "for": "5m",
+        "description": "spsak har ikke mottatt en eneste søknad siste timen",
+        "action": "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger",
+        "sla": "respond within 1h, during office hours",
+        "severity": "danger"
       }
     ]
   }


### PR DESCRIPTION
Setter opp alarmer i test og prod på at vi ikke mottar sykmeldinger og søknader. Jeg tenker at det er lurt å ha i test også, men da med ganske mye slack. 

For å begrense alarmer til arbeidstid bruker jeg hour(). Den er dessverre slave til UTC, så den vil svinge litt med sommertid osv, men det er bedre enn ingenting.